### PR TITLE
Disale udev support in bluez

### DIFF
--- a/org.subsurface_divelog.Subsurface.yaml
+++ b/org.subsurface_divelog.Subsurface.yaml
@@ -88,6 +88,7 @@ modules:
   config-opts:
   - --disable-datafiles
   - --disable-systemd
+  - --disable-udev
   - --enable-library
   - --prefix=/app
   - --sysconfdir=/app/etc


### PR DESCRIPTION
There is no udev daemon in runtime and udev functionality isn't exposed in flatpak environment thus building udev functionality in bluez is unnecessary and adds bloat.