### PR TITLE
Update org.kde.Sdk to version 5.15-23.08

### DIFF
--- a/org.subsurface_divelog.Subsurface.yaml
+++ b/org.subsurface_divelog.Subsurface.yaml
@@ -1,9 +1,9 @@
 app-id: org.subsurface_divelog.Subsurface
 sdk: org.kde.Sdk
 runtime: org.kde.Platform
-runtime-version: 5.15-22.08
+runtime-version: 5.15-23.08
 base: io.qt.qtwebkit.BaseApp
-base-version: 5.15-22.08
+base-version: 5.15-23.08
 command: subsurface
 rename-icon: subsurface-icon
 rename-appdata-file: subsurface.appdata.xml


### PR DESCRIPTION
This updates org.kde.Sdk and io.qt.qtwebkit.BaseApp to 5.15-23.08, so flatpak stops complaining about the deprecated version 5.15-22.08.