### PR TITLE
Re-Enable BlueZ, bump Subsurface

### DIFF
--- a/org.subsurface_divelog.Subsurface.yaml
+++ b/org.subsurface_divelog.Subsurface.yaml
@@ -204,7 +204,7 @@ modules:
       # https://subsurface.github.io/en/release/2023/12/release-changes/
       - type: git # use git in order to make HandleVersionGeneration.cmake work
         url: https://github.com/subsurface/subsurface
-        commit: 2af18dfa3665e154bd7a1011422f40b4d3cc6f0a
+        commit: 972b7a0643f0b5c98253c5dc4ad43951668f04a2
         x-checker-data:
           type: json
           url: https://api.github.com/repos/subsurface/subsurface/branches/master

--- a/org.subsurface_divelog.Subsurface.yaml
+++ b/org.subsurface_divelog.Subsurface.yaml
@@ -116,17 +116,17 @@ modules:
       - --disable-tools
       - --disable-monitor
       - --disable-udev
+      - --disable-cups
       - --prefix=/app
       - --sysconfdir=/app/etc
     sources:
       - type: archive
-        url: http://www.kernel.org/pub/linux/bluetooth/bluez-5.72.tar.xz
-        sha256: 499d7fa345a996c1bb650f5c6749e1d929111fa6ece0be0e98687fee6124536e
-        # temporarily disabled, since newer versions can't be buiilt without CUPS support
-        #x-checker-data:
-        #  type: anitya
-        #  project-id: 10029
-        #  url-template: http://www.kernel.org/pub/linux/bluetooth/bluez-$version.tar.xz
+        url: http://www.kernel.org/pub/linux/bluetooth/bluez-5.79.tar.xz
+        sha256: 4164a5303a9f71c70f48c03ff60be34231b568d93a9ad5e79928d34e6aa0ea8a 
+        x-checker-data:
+          type: anitya
+          project-id: 10029
+          url-template: http://www.kernel.org/pub/linux/bluetooth/bluez-$version.tar.xz
 
   - name: qtconnectivity
     buildsystem: simple


### PR DESCRIPTION
- Re-enable BlueZ and bump version to 5.79

- Update subsurface to most recent commit