### PR TITLE
Update to 6.0.5585.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .flatpak-builder
 subsurface-build
 subsurface-repo
+repo
+.vscode

--- a/org.subsurface_divelog.Subsurface.yaml
+++ b/org.subsurface_divelog.Subsurface.yaml
@@ -203,14 +203,14 @@ modules:
         commands:
           - sed -e "s|setDesktopFileName(\"subsurface\")|setDesktopFileName(\"org.subsurface_divelog.Subsurface\")|"
             -i core/qt-init.cpp
-          - scripts/get-version.sh --no-fetch 4 > .gitversion
-          - git log -1 --format="%at" | xargs -I{} date -d @{} +%Y-%m-%d > .gitdate
           # Leave the build number for version.cmake's calls to get-version.sh during the build.
           # Write to a temp file first because '>' truncates the target before the script runs,
           # and get-version.sh checks for 'latest-subsurface-buildnumber' as an input file.
           - scripts/get-version.sh --no-fetch 1 > latest-subsurface-buildnumber.tmp
             && mv latest-subsurface-buildnumber.tmp latest-subsurface-buildnumber
           - echo "CICD-release" > latest-subsurface-buildnumber-extension
+          - "{ scripts/get-version.sh --no-fetch 3; printf '-'; cat latest-subsurface-buildnumber-extension; } > .gitversion"
+          - git log -1 --format="%at" | xargs -I{} date -d @{} +%Y-%m-%d > .gitdate
           # Remove tags so that add-version-to-metainfo.sh falls back to .gitversion instead of 'git describe'
           - git tag -l | xargs -r git tag -d
           - rm -rf nightly-builds

--- a/org.subsurface_divelog.Subsurface.yaml
+++ b/org.subsurface_divelog.Subsurface.yaml
@@ -10,6 +10,7 @@ rename-desktop-file: subsurface.desktop
 finish-args:
   - --socket=wayland
   - --socket=fallback-x11
+  - --socket=cups
   - --share=ipc
   - --share=network
   - --allow=bluetooth

--- a/org.subsurface_divelog.Subsurface.yaml
+++ b/org.subsurface_divelog.Subsurface.yaml
@@ -204,8 +204,11 @@ modules:
           - sed -e "s|setDesktopFileName(\"subsurface\")|setDesktopFileName(\"org.subsurface_divelog.Subsurface\")|"
             -i core/qt-init.cpp
           - scripts/get-version.sh --no-fetch 4 > .gitversion
-          # Leave the build number for version.cmake's calls to get-version.sh during the build
-          - scripts/get-version.sh --no-fetch 1 > latest-subsurface-buildnumber
+          # Leave the build number for version.cmake's calls to get-version.sh during the build.
+          # Write to a temp file first because '>' truncates the target before the script runs,
+          # and get-version.sh checks for 'latest-subsurface-buildnumber' as an input file.
+          - scripts/get-version.sh --no-fetch 1 > latest-subsurface-buildnumber.tmp
+            && mv latest-subsurface-buildnumber.tmp latest-subsurface-buildnumber
           - git log -1 --format="%at" | xargs -I{} date -d @{} +%Y-%m-%d > .gitdate
           # Remove tags so that add-version-to-metainfo.sh falls back to .gitversion instead of 'git describe'
           - git tag -l | xargs -r git tag -d

--- a/org.subsurface_divelog.Subsurface.yaml
+++ b/org.subsurface_divelog.Subsurface.yaml
@@ -13,9 +13,11 @@ finish-args:
   - --socket=fallback-x11
   - --share=ipc
   - --share=network
+  - --allow=bluetooth
   - --device=all # required to talk to dive computers
   - --system-talk-name=org.bluez # required to talk to dive computers
   - --filesystem=xdg-config/kdeglobals:ro # gives application access to kdeglobals
+  - --filesystem=~/.subsurface # read and write configuration and default logbook location
   - --talk-name=com.canonical.AppMenu.Registrar # required for global menu
 cleanup-commands:
   - /app/cleanup-BaseApp.sh
@@ -173,9 +175,6 @@ modules:
   - name: subsurface
     buildsystem: cmake
     builddir: true
-    build-options:
-      env:
-        CANONICALVERSION: 6.0.5581
     config-opts:
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo
       - -DFTDISUPPORT=ON
@@ -189,6 +188,12 @@ modules:
       - type: git # use git in order to make HandleVersionGeneration.cmake work
         url: https://github.com/subsurface/subsurface
         commit: 33edd0237b2724857a9ab20f59560a59e8cc8db1
+      # get-version.sh requires the nightly-builds repo to look up the build number for the current commit;
+      # provide it as a source so it is fetched before network access is disabled for the build
+      - type: git
+        url: https://github.com/subsurface/nightly-builds
+        commit: 48fb3ce6f1893ce5aa7d33eb79d270f368f7db2d
+        dest: nightly-builds
       - type: shell
         commands:
           - cd libdivecomputer && autoreconf --install && ./configure --prefix=/app
@@ -197,6 +202,11 @@ modules:
         commands:
           - sed -e "s|setDesktopFileName(\"subsurface\")|setDesktopFileName(\"org.subsurface_divelog.Subsurface\")|"
             -i core/qt-init.cpp
+          # Place the build number file where get-version.sh expects it (checked before any network access)
+          - cp nightly-builds/latest-subsurface-buildnumber .
+          - scripts/get-version.sh 4 > .gitversion
+          - git log -1 --format="%at" | xargs -I{} date -d @{} +%Y-%m-%d > .gitdate
+          - rm -rf nightly-builds
     # Tests are mandatory for this package update. Exclude the one network-dependent test because Flatpak builds run with network isolation.
     build-commands:
       - cd /run/build/subsurface/_flatpak_build && QT_QPA_PLATFORM=offscreen ctest --output-on-failure -E '^TestParsePerformance$'

--- a/org.subsurface_divelog.Subsurface.yaml
+++ b/org.subsurface_divelog.Subsurface.yaml
@@ -202,10 +202,6 @@ modules:
           - scripts/get-version.sh --no-fetch 1 > latest-subsurface-buildnumber.tmp
             && mv latest-subsurface-buildnumber.tmp latest-subsurface-buildnumber
           - echo "CICD-release" > latest-subsurface-buildnumber-extension
-          - "{ scripts/get-version.sh --no-fetch 3; printf '-'; cat latest-subsurface-buildnumber-extension; } > .gitversion"
-          - git log -1 --format="%at" | xargs -I{} date -d @{} +%Y-%m-%d > .gitdate
-          # Remove tags so that add-version-to-metainfo.sh falls back to .gitversion instead of 'git describe'
-          - git tag -l | xargs -r git tag -d
           - rm -rf nightly-builds
     # Tests are mandatory for this package update. Exclude the one network-dependent test because Flatpak builds run with network isolation.
     build-commands:

--- a/org.subsurface_divelog.Subsurface.yaml
+++ b/org.subsurface_divelog.Subsurface.yaml
@@ -1,9 +1,9 @@
 app-id: org.subsurface_divelog.Subsurface
 sdk: org.kde.Sdk
 runtime: org.kde.Platform
-runtime-version: 5.15-23.08
+runtime-version: 5.15-25.08
 base: io.qt.qtwebkit.BaseApp
-base-version: 5.15-23.08
+base-version: 5.15-25.08
 command: subsurface
 rename-icon: subsurface-icon
 rename-appdata-file: subsurface.metainfo.xml
@@ -28,27 +28,6 @@ cleanup:
   - '*.a'
   - '*.la'
 modules:
-  - shared-modules/libusb/libusb.json
-
-  - name: libical
-    buildsystem: cmake-ninja
-    config-opts:
-      - -DCMAKE_BUILD_TYPE=Release
-      - -DBUILD_SHARED_LIBS:BOOL=ON
-      - -DICAL_GLIB=true
-      - -DGOBJECT_INTROSPECTION=true
-      - -DICAL_GLIB_VAPI=true
-      - -DICAL_BUILD_DOCS=false
-      - -DICAL_GLIB_VAPI=False
-    sources:
-      - type: archive
-        url: https://github.com/libical/libical/archive/v3.0.19.tar.gz
-        sha256: 6a1e7f0f50a399cbad826bcc286ce10d7151f3df7cc103f641de15160523c73f
-        x-checker-data:
-          type: anitya
-          project-id: 1637
-          url-template: https://github.com/libical/libical/archive/v$version.tar.gz
-
   - name: libssh2
     buildsystem: cmake-ninja
     config-opts:
@@ -69,8 +48,8 @@ modules:
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo
     sources:
       - type: archive
-        url: https://github.com/nih-at/libzip/archive/v1.11.2.tar.gz
-        sha256: 447dbc1d0e8c319d1e0abc34521d23bec483349c4be0b1cab0e17ef5cf6a4e82
+        url: https://github.com/nih-at/libzip/archive/v1.11.4.tar.gz
+        sha256: 4844595615e2436e3cf1ed46a1b260fbdaf8b8fa8f2b594e8b5d8162c696b8b2
         x-checker-data:
           type: anitya
           project-id: 10649
@@ -95,8 +74,8 @@ modules:
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo
     sources:
       - type: archive
-        url: https://github.com/libgit2/libgit2/archive/v1.9.0.tar.gz
-        sha256: 75b27d4d6df44bd34e2f70663cfd998f5ec41e680e1e593238bbe517a84c7ed2
+        url: https://github.com/libgit2/libgit2/archive/v1.9.2.tar.gz
+        sha256: 6f097c82fc06ece4f40539fb17e9d41baf1a5a2fc26b1b8562d21b89bc355fe6
         x-checker-data:
           type: anitya
           project-id: 1627
@@ -141,15 +120,13 @@ modules:
     #       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       - type: git
         url: https://github.com/qt/qtconnectivity
-        tag: v5.15.16-lts-lgpl
-        commit: b242dc4fd4bd68809872d8c1d6c1e63825692893
+        tag: v5.15.18-lts-lgpl
+        commit: 5b2159be824888876953e263204039e89f59c4c1
         x-checker-data:
           type: anitya
           project-id: 153467
           tag-template: v$version
           stable-only: true
-          versions:
-            <: '6'
 
     build-commands:
       - qmake
@@ -183,6 +160,7 @@ modules:
     config-opts:
       - -DLIB_SUFFIX=
       - -Wno-dev # suppress warning for project developers
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
     sources:
       - type: archive
         url: https://www.intra2net.com/en/developer/libftdi/download/libftdi1-1.5.tar.bz2
@@ -195,28 +173,33 @@ modules:
   - name: subsurface
     buildsystem: cmake
     builddir: true
+    build-options:
+      env:
+        CANONICALVERSION: 6.0.5581
+        CANONICALVERSION_4: 6.0.5581.0
     config-opts:
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo
       - -DFTDISUPPORT=ON
+      - -DNO_USERMANUAL=ON
       - -DQt5WebKitWidgets_DIR=/app/lib/cmake/Qt5WebKitWidgets
+      - -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+      - -DBUILD_TESTS=ON
     sources:
       # Subsurface has switched to a rolling release
       # https://subsurface.github.io/en/release/2023/12/release-changes/
       - type: git # use git in order to make HandleVersionGeneration.cmake work
         url: https://github.com/subsurface/subsurface
-        commit: 2af18dfa3665e154bd7a1011422f40b4d3cc6f0a
+        commit: 33edd0237b2724857a9ab20f59560a59e8cc8db1
       - type: shell
         commands:
           - cd libdivecomputer && autoreconf --install && ./configure --prefix=/app
-            && make && make install
+            && make && mkdir -p /app/include && make install
       - type: shell
         commands:
           - sed -e "s|setDesktopFileName(\"subsurface\")|setDesktopFileName(\"org.subsurface_divelog.Subsurface\")|"
             -i core/qt-init.cpp
           - sed -e "s|<id>org.subsurface_divelog.subsurface</id>|<id>org.subsurface_divelog.Subsurface</id>|"
             -i metainfo/subsurface.metainfo.xml.in
-    # copied from
-    # https://github.com/texstudio-org/texstudio/blob/master/.github/workflows/ci.yml (setting QT_QPA_PLATFORM) and
-    # https://github.com/subsurface/subsurface/blob/master/README_TESTING.md
+    # Tests are mandatory for this package update. Exclude the one network-dependent test because Flatpak builds run with network isolation.
     build-commands:
-      - cd tests && QT_QPA_PLATFORM=offscreen ctest # if tests fail, use -V option to get verbose output
+      - cd /run/build/subsurface/_flatpak_build && QT_QPA_PLATFORM=offscreen ctest --output-on-failure -E '^TestParsePerformance$'

--- a/org.subsurface_divelog.Subsurface.yaml
+++ b/org.subsurface_divelog.Subsurface.yaml
@@ -176,7 +176,6 @@ modules:
     build-options:
       env:
         CANONICALVERSION: 6.0.5581
-        CANONICALVERSION_4: 6.0.5581.0
     config-opts:
       - -DCMAKE_BUILD_TYPE=RelWithDebInfo
       - -DFTDISUPPORT=ON
@@ -198,8 +197,6 @@ modules:
         commands:
           - sed -e "s|setDesktopFileName(\"subsurface\")|setDesktopFileName(\"org.subsurface_divelog.Subsurface\")|"
             -i core/qt-init.cpp
-          - sed -e "s|<id>org.subsurface_divelog.subsurface</id>|<id>org.subsurface_divelog.Subsurface</id>|"
-            -i metainfo/subsurface.metainfo.xml.in
     # Tests are mandatory for this package update. Exclude the one network-dependent test because Flatpak builds run with network isolation.
     build-commands:
       - cd /run/build/subsurface/_flatpak_build && QT_QPA_PLATFORM=offscreen ctest --output-on-failure -E '^TestParsePerformance$'

--- a/org.subsurface_divelog.Subsurface.yaml
+++ b/org.subsurface_divelog.Subsurface.yaml
@@ -204,12 +204,13 @@ modules:
           - sed -e "s|setDesktopFileName(\"subsurface\")|setDesktopFileName(\"org.subsurface_divelog.Subsurface\")|"
             -i core/qt-init.cpp
           - scripts/get-version.sh --no-fetch 4 > .gitversion
+          - git log -1 --format="%at" | xargs -I{} date -d @{} +%Y-%m-%d > .gitdate
           # Leave the build number for version.cmake's calls to get-version.sh during the build.
           # Write to a temp file first because '>' truncates the target before the script runs,
           # and get-version.sh checks for 'latest-subsurface-buildnumber' as an input file.
           - scripts/get-version.sh --no-fetch 1 > latest-subsurface-buildnumber.tmp
             && mv latest-subsurface-buildnumber.tmp latest-subsurface-buildnumber
-          - git log -1 --format="%at" | xargs -I{} date -d @{} +%Y-%m-%d > .gitdate
+          - echo "CICD-release" > latest-subsurface-buildnumber-extension
           # Remove tags so that add-version-to-metainfo.sh falls back to .gitversion instead of 'git describe'
           - git tag -l | xargs -r git tag -d
           - rm -rf nightly-builds

--- a/org.subsurface_divelog.Subsurface.yaml
+++ b/org.subsurface_divelog.Subsurface.yaml
@@ -187,12 +187,12 @@ modules:
       # https://subsurface.github.io/en/release/2023/12/release-changes/
       - type: git # use git in order to make HandleVersionGeneration.cmake work
         url: https://github.com/subsurface/subsurface
-        commit: 33edd0237b2724857a9ab20f59560a59e8cc8db1
+        commit: 7fc7148822c9a58d4a9e3ea91f080b7b099cb936
       # get-version.sh requires the nightly-builds repo to look up the build number for the current commit;
       # provide it as a source so it is fetched before network access is disabled for the build
       - type: git
         url: https://github.com/subsurface/nightly-builds
-        commit: 48fb3ce6f1893ce5aa7d33eb79d270f368f7db2d
+        commit: 7b0b3e8324b57ac76bbbde6e6f227415593036b1
         dest: nightly-builds
       - type: shell
         commands:
@@ -202,10 +202,10 @@ modules:
         commands:
           - sed -e "s|setDesktopFileName(\"subsurface\")|setDesktopFileName(\"org.subsurface_divelog.Subsurface\")|"
             -i core/qt-init.cpp
-          # Place the build number file where get-version.sh expects it (checked before any network access)
-          - cp nightly-builds/latest-subsurface-buildnumber .
-          - scripts/get-version.sh 4 > .gitversion
+          - scripts/get-version.sh --no-fetch 4 > .gitversion
           - git log -1 --format="%at" | xargs -I{} date -d @{} +%Y-%m-%d > .gitdate
+          # Remove tags so that add-version-to-metainfo.sh falls back to .gitversion instead of 'git describe'
+          - git tag -l | xargs -r git tag -d
           - rm -rf nightly-builds
     # Tests are mandatory for this package update. Exclude the one network-dependent test because Flatpak builds run with network isolation.
     build-commands:

--- a/org.subsurface_divelog.Subsurface.yaml
+++ b/org.subsurface_divelog.Subsurface.yaml
@@ -176,7 +176,7 @@ modules:
       # https://subsurface.github.io/en/release/2023/12/release-changes/
       - type: git # use git in order to make HandleVersionGeneration.cmake work
         url: https://github.com/subsurface/subsurface
-        commit: 112b31cb2a87a40d4c3b5b3b12f9a95b0e0b8a3a
+        commit: 99f7978e51a4c826ae0673e35ee4abd8725f41e7
         disable-shallow-clone: true
       # get-version.sh requires the nightly-builds repo to look up the build number for the current commit;
       # provide it as a source so it is fetched before network access is disabled for the build

--- a/org.subsurface_divelog.Subsurface.yaml
+++ b/org.subsurface_divelog.Subsurface.yaml
@@ -187,12 +187,13 @@ modules:
       # https://subsurface.github.io/en/release/2023/12/release-changes/
       - type: git # use git in order to make HandleVersionGeneration.cmake work
         url: https://github.com/subsurface/subsurface
-        commit: 7fc7148822c9a58d4a9e3ea91f080b7b099cb936
+        commit: 548a20f714e414aa8bba154d1fb02ae0f3bf79c3
       # get-version.sh requires the nightly-builds repo to look up the build number for the current commit;
       # provide it as a source so it is fetched before network access is disabled for the build
       - type: git
         url: https://github.com/subsurface/nightly-builds
         commit: 7b0b3e8324b57ac76bbbde6e6f227415593036b1
+        disable-shallow-clone: true
         dest: nightly-builds
       - type: shell
         commands:

--- a/org.subsurface_divelog.Subsurface.yaml
+++ b/org.subsurface_divelog.Subsurface.yaml
@@ -118,6 +118,8 @@ modules:
           project-id: 153467
           tag-template: v$version
           stable-only: true
+          versions:
+            <: 6
 
     build-commands:
       - qmake
@@ -207,4 +209,4 @@ modules:
             -i subsurface.desktop
     # Tests are mandatory for this package update. Exclude the one network-dependent test because Flatpak builds run with network isolation.
     build-commands:
-      - cd /run/build/subsurface/_flatpak_build && QT_QPA_PLATFORM=offscreen ctest --output-on-failure -E '^TestParsePerformance$'
+      - QT_QPA_PLATFORM=offscreen ctest --output-on-failure -E '^TestParsePerformance$'

--- a/org.subsurface_divelog.Subsurface.yaml
+++ b/org.subsurface_divelog.Subsurface.yaml
@@ -1,9 +1,9 @@
 app-id: org.subsurface_divelog.Subsurface
 sdk: org.kde.Sdk
 runtime: org.kde.Platform
-runtime-version: 5.15-25.08
+runtime-version: "5.15"
 base: io.qt.qtwebkit.BaseApp
-base-version: 5.15-25.08
+base-version: "5.15"
 command: subsurface
 rename-icon: subsurface-icon
 rename-appdata-file: subsurface.metainfo.xml
@@ -30,6 +30,8 @@ cleanup:
   - '*.a'
   - '*.la'
 modules:
+  - shared-modules/libusb/libusb.json
+
   - name: libssh2
     buildsystem: cmake-ninja
     config-opts:
@@ -56,19 +58,6 @@ modules:
           type: anitya
           project-id: 10649
           url-template: https://github.com/nih-at/libzip/archive/v$version.tar.gz
-
-  - name: grantlee
-    buildsystem: cmake-ninja
-    config-opts:
-      - -DCMAKE_BUILD_TYPE=RelWithDebInfo
-    sources:
-      - type: archive
-        url: https://github.com/steveire/grantlee/archive/v5.3.1.tar.gz
-        sha256: ba288ae9ed37ec0c3622ceb40ae1f7e1e6b2ea89216ad8587f0863d64be24f06
-        x-checker-data:
-          type: anitya
-          project-id: 21448
-          url-template: https://github.com/steveire/grantlee/archive/v$version.tar.gz
 
   - name: libgit2
     buildsystem: cmake-ninja
@@ -187,7 +176,12 @@ modules:
       # https://subsurface.github.io/en/release/2023/12/release-changes/
       - type: git # use git in order to make HandleVersionGeneration.cmake work
         url: https://github.com/subsurface/subsurface
+<<<<<<< Updated upstream
         commit: 548a20f714e414aa8bba154d1fb02ae0f3bf79c3
+=======
+        commit: 112b31cb2a87a40d4c3b5b3b12f9a95b0e0b8a3a
+        disable-shallow-clone: true
+>>>>>>> Stashed changes
       # get-version.sh requires the nightly-builds repo to look up the build number for the current commit;
       # provide it as a source so it is fetched before network access is disabled for the build
       - type: git

--- a/org.subsurface_divelog.Subsurface.yaml
+++ b/org.subsurface_divelog.Subsurface.yaml
@@ -203,6 +203,8 @@ modules:
           - sed -e "s|setDesktopFileName(\"subsurface\")|setDesktopFileName(\"org.subsurface_divelog.Subsurface\")|"
             -i core/qt-init.cpp
           - scripts/get-version.sh --no-fetch 4 > .gitversion
+          # Leave the build number for version.cmake's calls to get-version.sh during the build
+          - scripts/get-version.sh --no-fetch 1 > latest-subsurface-buildnumber
           - git log -1 --format="%at" | xargs -I{} date -d @{} +%Y-%m-%d > .gitdate
           # Remove tags so that add-version-to-metainfo.sh falls back to .gitversion instead of 'git describe'
           - git tag -l | xargs -r git tag -d

--- a/org.subsurface_divelog.Subsurface.yaml
+++ b/org.subsurface_divelog.Subsurface.yaml
@@ -5,7 +5,6 @@ runtime-version: "5.15"
 base: io.qt.qtwebkit.BaseApp
 base-version: "5.15"
 command: subsurface
-rename-icon: subsurface-icon
 rename-appdata-file: subsurface.metainfo.xml
 rename-desktop-file: subsurface.desktop
 finish-args:
@@ -203,6 +202,8 @@ modules:
             && mv latest-subsurface-buildnumber.tmp latest-subsurface-buildnumber
           - echo "CICD-release" > latest-subsurface-buildnumber-extension
           - rm -rf nightly-builds
+          - sed -e "s|subsurface-icon|org.subsurface_divelog.Subsurface|"
+            -i subsurface.desktop
     # Tests are mandatory for this package update. Exclude the one network-dependent test because Flatpak builds run with network isolation.
     build-commands:
       - cd /run/build/subsurface/_flatpak_build && QT_QPA_PLATFORM=offscreen ctest --output-on-failure -E '^TestParsePerformance$'

--- a/org.subsurface_divelog.Subsurface.yaml
+++ b/org.subsurface_divelog.Subsurface.yaml
@@ -176,12 +176,8 @@ modules:
       # https://subsurface.github.io/en/release/2023/12/release-changes/
       - type: git # use git in order to make HandleVersionGeneration.cmake work
         url: https://github.com/subsurface/subsurface
-<<<<<<< Updated upstream
-        commit: 548a20f714e414aa8bba154d1fb02ae0f3bf79c3
-=======
         commit: 112b31cb2a87a40d4c3b5b3b12f9a95b0e0b8a3a
         disable-shallow-clone: true
->>>>>>> Stashed changes
       # get-version.sh requires the nightly-builds repo to look up the build number for the current commit;
       # provide it as a source so it is fetched before network access is disabled for the build
       - type: git
@@ -197,6 +193,9 @@ modules:
         commands:
           - sed -e "s|setDesktopFileName(\"subsurface\")|setDesktopFileName(\"org.subsurface_divelog.Subsurface\")|"
             -i core/qt-init.cpp
+          # Disable Git LFS hooks in nightly-builds; git-lfs is not available in the sandbox
+          # and the post-checkout hook would make 'git checkout' fail with exit code 2.
+          - rm -f nightly-builds/.git/hooks/post-checkout
           # Leave the build number for version.cmake's calls to get-version.sh during the build.
           # Write to a temp file first because '>' truncates the target before the script runs,
           # and get-version.sh checks for 'latest-subsurface-buildnumber' as an input file.

--- a/python3-docutils.json
+++ b/python3-docutils.json
@@ -7,8 +7,8 @@
     "sources": [
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/4c/17/559b4d020f4b46e0287a2eddf2d8ebf76318fd3bd495f1625414b052fdc9/docutils-0.17.1.tar.gz",
-            "sha256": "686577d2e4c32380bb50cbb22f575ed742d58168cee37e99117a854bcd88f125"
+            "url": "https://files.pythonhosted.org/packages/26/87/f238c0670b94533ac0353a4e2a1a771a0cc73277b88bff23d3ae35a256c1/docutils-0.20.1-py3-none-any.whl",
+            "sha256": "96f387a2c5562db4476f09f13bbab2192e764cac08ebbf3a34a95d9b1e4a59d6"
         }
     ]
 }


### PR DESCRIPTION
- **Update to 6.0.5581.**
- **Clean up the versioning.**
- **Automate the version generation.**
- **Use the offline version of 'get-version.sh'.**
- **Prime the pump for 'get-version.sh'.**
- **Get all of the branches for nightly-builds.**
- **Fix shell redirection.**
- **Add the correct extension.**
- **Make the metadata version look right.**
- **Simplify the build.**
- **Fix the version evaluation.**
- **Simplify the version injection.**
- **Update to Subsurface CICD release 5585.**
- **use the redrawn icon**
- **Request additional permissions**
- **we haven't used Grantlee in years**
- **Update 'shared-modules'.**
